### PR TITLE
Add user to container

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -80,7 +80,10 @@ if [ "$headless" = "false" ]; then
 fi
 
 # Build docker image up to dev stage
-DOCKER_BUILDKIT=1 docker build \
+docker build \
+    --build-arg USER_ID=$(id -u) \
+    --build-arg GROUP_ID=$(id -g) \
+    --build-arg USERNAME=$(whoami) \
     -t av_tools:latest-dev \
     -f Dockerfile --target dev .
 
@@ -89,6 +92,7 @@ SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
 # Run docker image with local code volumes for development
 docker run -it --rm --net host --privileged \
+    --user "$(id -u):$(id -g)" \
     ${MOUNT_X} \
     -e XAUTHORITY="${XAUTHORITY}" \
     -e XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \

--- a/runtime.sh
+++ b/runtime.sh
@@ -82,13 +82,17 @@ if [ ! -d "$ROSBAGS_DIR" -a "$CHECK_PATH" = true ]; then
     exit 1
 fi
 
-# Build docker image only up to base stage
-DOCKER_BUILDKIT=1 docker build \
+# Build docker image only up to runtime stage
+docker build \
+    --build-arg USER_ID=$(id -u) \
+    --build-arg GROUP_ID=$(id -g) \
+    --build-arg USERNAME=$(whoami) \
     -t av_tools:latest \
     -f Dockerfile --target runtime .
 
 # Run docker image
 docker run -it --rm --net host --privileged \
+    --user "$(id -u):$(id -g)" \
     -v /dev:/dev \
     -v /tmp:/tmp \
     $CYCLONE_VOL \


### PR DESCRIPTION
- Avoid running and creating files as root
- Use curent host username, user_id and user_group_id to build and run the container with `dev.sh` and `runtime.sh`
- Remove DOCKER_BUILDKIT=1 as it is no longer needed