### PR TITLE
Improve mcap recording

### DIFF
--- a/config/mcap_cfg.yaml
+++ b/config/mcap_cfg.yaml
@@ -5,7 +5,7 @@ noSummaryCRC: false
 noChunking: false
 noMessageIndex: false
 noSummary: false
-chunkSize: 786432
+chunkSize: 62914560 # 60 MiB
 compression: "None"
 compressionLevel: "Default"
 forceCompression: false


### PR DESCRIPTION
- Increase the recording `chunksize` from `786432` to `62914560` bytes (`60 MiB`) to reduce the overall number of chunks in the recorded rosbag  
  - `786432` bytes is insufficient to hold even a single image or point cloud message, causing multiple chunks to be read and decoded for one message, which leads to overhead when reading rosbags in Foxglove  
  - By choosing a chunk size to capture approximately 0.1 seconds of data, we can include at least one point cloud and 12 camera messages, plus other sensors, within a single chunk  
  - In the event of a recording or vehicle server failure, at most 0.1 seconds of data would be lost, which is an acceptable trade-off  
  - To determine `60 MiB`, a recent rosbag was analysed: we split every ~10 GiB for 18 seconds of data. Hence, the 0.1-second interval uses about `10 GiB / 18 sec / 10 ≈ 0.055 GiB ≈ 59770000 bytes`. We can then round up to `60 MiB` = `62914560 bytes` 

See this [blog](https://foxglove.dev/blog/understanding-mcap-chunk-size-and-compression#:~:text=When%20writing%20in%20chunked%20mode%2C,option) for further reference